### PR TITLE
Fix for BECAL track projections

### DIFF
--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
@@ -181,7 +181,7 @@ void RawTowerBuilderByHitIndexBECAL::CreateNodes(PHCompositeNode *topNode)
 
   // Create the tower geometry node on the tree
   m_Geoms = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(m_Detector));
-  m_Geoms->set_radius(); 
+  
   string NodeNameTowerGeometries = "TOWERGEOM_" + m_Detector;
 
   PHIODataNode<PHObject> *geomNode = new PHIODataNode<PHObject>(m_Geoms, NodeNameTowerGeometries, "PHObject");
@@ -294,12 +294,25 @@ bool RawTowerBuilderByHitIndexBECAL::ReadGeometryFromTable()
       {
         thickness_wall = parit->second;  // in cm
       }
+
+      parit = m_GlobalParameterMap.find("radius");
+      if (parit != m_GlobalParameterMap.end())
+      {
+        radius = parit->second;  // in cm
+      }
       
+      parit = m_GlobalParameterMap.find("tower_length");
+      if (parit != m_GlobalParameterMap.end())
+      {
+        tower_length = parit->second;  // in cm
+      }
+
     }
 
-  
-
   }
+
+  m_Geoms->set_radius(radius + 0.5*tower_length); 
+  //cout << PHWHERE << "BECAL radius set to " <<  m_Geoms->get_radius() << " cm" << endl; 
     
   RawTowerGeomContainer::ConstRange all_towers = m_Geoms->get_tower_geometries();
    

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.cc
@@ -8,7 +8,7 @@
 #include <calobase/RawTowerGeom.h>             // for RawTowerGeom
 #include <calobase/RawTowerGeomv4.h>
 #include <calobase/RawTowerGeomContainer.h>    // for RawTowerGeomContainer
-#include <calobase/RawTowerGeomContainerv1.h>
+#include <calobase/RawTowerGeomContainer_Cylinderv1.h>
 
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
@@ -180,7 +180,8 @@ void RawTowerBuilderByHitIndexBECAL::CreateNodes(PHCompositeNode *topNode)
   }
 
   // Create the tower geometry node on the tree
-  m_Geoms = new RawTowerGeomContainerv1(RawTowerDefs::convert_name_to_caloid(m_Detector));
+  m_Geoms = new RawTowerGeomContainer_Cylinderv1(RawTowerDefs::convert_name_to_caloid(m_Detector));
+  m_Geoms->set_radius(); 
   string NodeNameTowerGeometries = "TOWERGEOM_" + m_Detector;
 
   PHIODataNode<PHObject> *geomNode = new PHIODataNode<PHObject>(m_Geoms, NodeNameTowerGeometries, "PHObject");

--- a/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.h
+++ b/simulation/g4simulation/g4eiccalos/RawTowerBuilderByHitIndexBECAL.h
@@ -85,6 +85,8 @@ class RawTowerBuilderByHitIndexBECAL : public SubsysReco
   RawTowerDefs::CalorimeterId m_CaloId;
 
   double thickness_wall = -1.; 
+  double radius = 85.0; 
+  double tower_length = 45.5; 
 
   double m_Emin;
 


### PR DESCRIPTION
This modifies the RawTowerGeomContainer used for the BECAL to work properly with track projections. 